### PR TITLE
Fixed - was passing data value as array

### DIFF
--- a/src/tutorial/1-useState/setup/3-useState-array.tsx
+++ b/src/tutorial/1-useState/setup/3-useState-array.tsx
@@ -7,16 +7,16 @@ type People = {
 };
 
 const UseStateArray = () => {
-  const [people, setPeople] = useState<People[]>([data]);
+  const [people, setPeople] = useState<People[]>(data);
+
   console.log(setPeople);
   console.log(people);
   return (
     <>
       {people.map((person) => {
-        const { id, name } = person;
+        const { name, id } = person;
         return (
-          <div>
-            <h1>{id}</h1>
+          <div key={id} className="item">
             <h2>{name}</h2>
           </div>
         );


### PR DESCRIPTION
Removed the data object and kept the array parameters in the type passthrough and it fixed issue.

**THIS:**

```
type People = {
  id: number;
  name: string;
};

  const [people, setPeople] = useState<People[]>(data);
```

**INSTEAD OF THIS:**

```
type People = {
  id: number;
  name: string;
};

  const [people, setPeople] = useState<People[]>([data]);
```
